### PR TITLE
fix(cmake): Use Conan Setting for CMake Output Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.15)
 project(cgsolver)
 set(PROJ_NAME ${PROJECT_NAME}) # avoid confusion with Conan pkgs
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -31,7 +27,7 @@ if(COMPILER_SUPPORTS_MARCH_NATIVE)
 endif()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup() # by default, sets CMAKE_LIBRARY_OUTPUT_DIRECTORY, CMAKE_RUNTIME_OUTPUT_DIRECTORY
 
 # find GTK-2.0 for OpenCV highgui
 # Only on Linux


### PR DESCRIPTION
By default Conan has set `CMAKE_LIBRARY_OUTPUT_DIRECTORY` and `CMAKE_RUNTIME_OUTPUT_DIRECTORY` by calling `conan_output_dirs_setup()` (see [documentation](https://docs.conan.io/en/latest/reference/generators/cmake.html#conan-basic-setup)). Removed manual set for CMake output dirs, to comply with Conan package standard. 