### PR TITLE
feat(ci): deprecate OpenCV in project 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_BINARY_DIR}/conan_toolchain.cmake" CAC
 message(STATUS "Used CMake toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 
 # required packages
-find_package(OpenCV REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(sciplot REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,11 @@ add_library(${PROJECT_NAME})
 file(GLOB_RECURSE SOURCE_FILES *.cpp *.c)
 file(GLOB_RECURSE HEADER_FILES *.hpp *.inl *.h)
 
+# Deprecate OpenCV visualizer
+list(REMOVE_ITEM SOURCE_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/visualization/visualizer/opencv_visualizer.cpp
+)
+
 # Add target sources
 target_sources(${PROJECT_NAME} PUBLIC ${SOURCE_FILES} ${HEADER_FILES})
 
@@ -18,16 +23,10 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   Eigen3::Eigen
   spdlog::spdlog
   fmt::fmt
-  opencv_core
-  opencv_highgui
-  opencv_imgcodecs
-  opencv_imgproc
+  sciplot::sciplot
 )
 
 # include dirs
-target_include_directories(${PROJECT_NAME} PUBLIC
-  ${OpenCV_INCLUDE_DIRS}
-)
 target_include_directories(${PROJECT_NAME} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,17 +9,17 @@ target_link_libraries(test_eigen PUBLIC
 )
 
 # add opencv examples
-add_executable(test_opencv test_opencv.cpp)
-target_link_libraries(test_opencv PUBLIC
-  opencv_core
-  opencv_highgui
-  opencv_imgcodecs
-  opencv_imgproc
-)
-
-target_include_directories(test_opencv PUBLIC
-  ${OpenCV_INCLUDE_DIRS}
-)
+# DEPRECATED
+# add_executable(test_opencv test_opencv.cpp)
+# target_link_libraries(test_opencv PUBLIC
+#   opencv_core
+#   opencv_highgui
+#   opencv_imgcodecs
+#   opencv_imgproc
+# )
+# target_include_directories(test_opencv PUBLIC
+#   ${OpenCV_INCLUDE_DIRS}
+# )
 
 find_package(sciplot CONFIG REQUIRED)
 add_executable(test_sciplot test_sciplot.cpp)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,6 @@
   "dependencies": [
     "eigen3",
     "spdlog",
-    "opencv",
     {"name": "sciplot", "version>=": "0.3.1"}
   ],
   "builtin-baseline": "657bfe23f401f234d2bea75c36f79777ad944d21"


### PR DESCRIPTION
Due to long CI build time, OpenCV dependency is to be deprecated. The use of OpenCV is optional, as it is only used in  visualization and the pipeline has already been replaced by Sciplot.