### PR TITLE
feat(visualization): add SFML Visualizer in main code base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,4 +321,3 @@ environment_run.sh.env
 tmp
 !.vscode/launch.json
 !.vscode/tasks.json
-CMake*.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ message(STATUS "Used CMake toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 find_package(spdlog REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(sciplot REQUIRED)
+find_package(SFML COMPONENTS system window graphics CONFIG REQUIRED)
 
 # --------------------------
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,29 @@
+{
+  "version": 4,
+  "configurePresets": [
+    {
+      "name": "Debug Windows 11",
+      "displayName": "Visual Studio Build Tools 2022 Release - amd64",
+      "description": "Using compilers for Visual Studio 17 2022 (x64 architecture)",
+      "generator": "Visual Studio 17 2022",
+      "toolset": "host=x64",
+      "architecture": "x64",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/${presetName}"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "Debug Windows 11",
+      "description": "",
+      "displayName": "x64 debug",
+      "configurePreset": "Debug Windows 11",
+      "cleanFirst": true,
+      "jobs": 16
+    }
+  ]
+}

--- a/examples/convex_hull.cpp
+++ b/examples/convex_hull.cpp
@@ -13,7 +13,7 @@
 #include "common/geometry/points2d.hpp"
 #include "visualization/drawable/line_string.hpp"
 #include "visualization/drawable/point_set.hpp"
-#include "visualization/visualizer/sciplot_visualizer.hpp"
+#include "visualization/visualizer/sfml_visualizer.hpp"
 
 using namespace cgzr;
 
@@ -33,7 +33,7 @@ int main() {
   auto results = convex_hull_solver->Solve(input_geometries);
 
   SPDLOG_INFO("Creating visualizer...");
-  visualization::SciplotVisualizer visualizer;
+  visualization::SfmlVisualizer visualizer;
 
   SPDLOG_INFO("Adding items to visualizer...");
   for (const auto& out_geometry : results) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   spdlog::spdlog
   fmt::fmt
   sciplot::sciplot
+  sfml-graphics
+  sfml-window
 )
 
 # include dirs

--- a/src/visualization/visualizer/sciplot_visualizer.cpp
+++ b/src/visualization/visualizer/sciplot_visualizer.cpp
@@ -7,7 +7,7 @@
 namespace cgzr {
 namespace visualization {
 
-void SciplotVisualizer::Visualize() const {
+void SciplotVisualizer::Visualize() {
   // Initialize plot
   sciplot::Plot2D plot;
 
@@ -22,10 +22,10 @@ void SciplotVisualizer::Visualize() const {
   plot.ylabel("y").fontName("Palatino").fontSize(12);
 
   // Set the x and y ranges
-  plot.xrange(world_min_.x() - PLOT_X_EXTEND_RATIO * std::abs(world_min_.x()),
-              world_max_.x() + PLOT_X_EXTEND_RATIO * std::abs(world_max_.x()));
-  plot.yrange(world_min_.y() - PLOT_Y_EXTEND_RATIO * std::abs(world_min_.y()),
-              world_max_.y() + PLOT_Y_EXTEND_RATIO * std::abs(world_max_.y()));
+  plot.xrange(world_min_.x() - kPlotExtendRatioX * std::abs(world_min_.x()),
+              world_max_.x() + kPlotExtendRatioX * std::abs(world_max_.x()));
+  plot.yrange(world_min_.y() - kPlotExtendRatioY * std::abs(world_min_.y()),
+              world_max_.y() + kPlotExtendRatioY * std::abs(world_max_.y()));
 
   // Draw shapes
   for (const auto& drawable : drawables_) {
@@ -47,7 +47,7 @@ void SciplotVisualizer::Visualize() const {
 
   // Create canvas to hold figure
   sciplot::Canvas canvas = {{fig}};
-  canvas.size(CANVAS_WIDTH, CANVAS_HEIGHT);
+  canvas.size(kCanvasWidth, kCanvasHeight);
 
   // Display objects
   canvas.show();

--- a/src/visualization/visualizer/sciplot_visualizer.hpp
+++ b/src/visualization/visualizer/sciplot_visualizer.hpp
@@ -10,13 +10,13 @@ namespace visualization {
 
 class SciplotVisualizer : public VisualizerBase {
  public:
-  void Visualize() const override;
+  void Visualize() override;
 
  private:
-  static constexpr unsigned int CANVAS_WIDTH = 500;
-  static constexpr unsigned int CANVAS_HEIGHT = 500;
-  static constexpr double PLOT_X_EXTEND_RATIO = 0.2;
-  static constexpr double PLOT_Y_EXTEND_RATIO = 0.2;
+  static constexpr unsigned int kCanvasWidth = 500;
+  static constexpr unsigned int kCanvasHeight = 500;
+  static constexpr double kPlotExtendRatioX = 0.2;
+  static constexpr double kPlotExtendRatioY = 0.2;
 
   void DrawPointSet(sciplot::Plot2D& plot, const DrawableBase* drawable) const;
   void DrawLineString(sciplot::Plot2D& plot,

--- a/src/visualization/visualizer/sfml_visualizer.cpp
+++ b/src/visualization/visualizer/sfml_visualizer.cpp
@@ -1,0 +1,141 @@
+#include "sfml_visualizer.hpp"
+
+#include <SFML/Graphics.hpp>
+
+#include "logging/logging.hpp"
+#include "visualization/drawable/line_string.hpp"
+#include "visualization/drawable/point_set.hpp"
+
+namespace cgzr {
+namespace visualization {
+
+namespace {
+inline sf::Color ToSfmlColor(const ColorRGB& color) {
+  sf::Uint8 r = static_cast<sf::Uint8>(color.r);
+  sf::Uint8 g = static_cast<sf::Uint8>(color.g);
+  sf::Uint8 b = static_cast<sf::Uint8>(color.b);
+  return sf::Color(r, g, b);
+}
+}  // namespace
+
+SfmlVisualizer::SfmlVisualizer() : VisualizerBase() {
+  // antialiasing
+  sf::ContextSettings window_settings;
+  window_settings.antialiasingLevel = 5;
+
+  window_.create(sf::VideoMode(kCanvasWidth + 2 * kCanvasWidthBuffer,
+                               kCanvasHeight + 2 * kCanvasHeightBuffer),
+                 "Visualization", sf::Style::Close, window_settings);
+}
+
+void SfmlVisualizer::Visualize() {
+  // Compute offset and scaling
+  auto [offset, scaling] = ComputeOffsetAndScaling();
+
+  // Main loop
+  while (window_.isOpen()) {
+    // check all the window's events that were triggered since the last
+    // iteration of the loop
+    sf::Event event;
+    while (window_.pollEvent(event)) {
+      // "close requested" event: we close the window
+      bool button_close = event.type == sf::Event::Closed;
+      bool key_q_or_esc = event.type == sf::Event::KeyPressed &&
+                          (event.key.code == sf::Keyboard::Q ||
+                           event.key.code == sf::Keyboard::Escape);
+      if (button_close || key_q_or_esc) {
+        window_.close();
+      }
+    }
+
+    // clear the window with white color
+    window_.clear(sf::Color::White);
+
+    // draw everything here...
+    for (const auto& drawable : drawables_) {
+      switch (drawable->Type()) {
+        case DrawableType::POINT_SET:
+          DrawPointSet(window_, drawable.get(), offset, scaling);
+          break;
+
+        case DrawableType::LINE_STRING:
+          DrawLineString(window_, drawable.get(), offset, scaling);
+
+        default:
+          break;
+      }
+    }
+
+    // end the current frame
+    window_.display();
+  }
+}
+
+void SfmlVisualizer::DrawPointSet(sf::RenderWindow& window,
+                                  const DrawableBase* drawable,
+                                  const Eigen::Vector2d offset,
+                                  const Eigen::Vector2d scaling) const {
+  const auto& point_set = static_cast<const PointSet*>(drawable);
+  if (point_set == nullptr) {
+    SPDLOG_ERROR("invalid point set as a drawable");
+  }
+  constexpr float kCircleRadius = 3.f;
+  for (const auto& vert : point_set->Vertices()) {
+    sf::CircleShape dot(kCircleRadius);
+    dot.setFillColor(ToSfmlColor(point_set->Color()));
+    // SFML draws circle in a way that centers at (kCircleRadius, kCircleRadius)
+    float vert_x = static_cast<float>((vert.x() - offset.x()) * scaling.x()) -
+                   kCircleRadius;
+    float vert_y = static_cast<float>((vert.y() - offset.y()) * scaling.y()) -
+                   kCircleRadius;
+    dot.move(kCanvasWidthBuffer + vert_x, kCanvasHeightBuffer + vert_y);
+    window.draw(dot);
+  }
+}
+
+void SfmlVisualizer::DrawLineString(sf::RenderWindow& window,
+                                    const DrawableBase* drawable,
+                                    const Eigen::Vector2d offset,
+                                    const Eigen::Vector2d scaling) const {
+  const auto& line_string = static_cast<const LineString*>(drawable);
+  if (line_string == nullptr) {
+    SPDLOG_ERROR("invalid line string as a drawable");
+  }
+
+  sf::Color color = ToSfmlColor(line_string->Color());
+
+  // SFML draws lines in {v0,v1}, {v2,v3}, {v4,v5} ...
+  std::vector<sf::Vertex> ordered_vertices;
+  ordered_vertices.reserve(2 * line_string->Edges().size());
+
+  for (const auto& [start, end] : line_string->Edges()) {
+    const auto& start_v = line_string->Vertices().at(start);
+    auto start_pos = sf::Vector2f(
+        kCanvasWidthBuffer +
+            static_cast<float>((start_v.x() - offset.x()) * scaling.x()),
+        kCanvasHeightBuffer +
+            static_cast<float>((start_v.y() - offset.y()) * scaling.y()));
+    ordered_vertices.emplace_back(start_pos, color);
+
+    const auto& end_v = line_string->Vertices().at(end);
+    auto end_pos = sf::Vector2f(
+        kCanvasWidthBuffer +
+            static_cast<float>((end_v.x() - offset.x()) * scaling.x()),
+        kCanvasHeightBuffer +
+            static_cast<float>((end_v.y() - offset.y()) * scaling.y()));
+    ordered_vertices.emplace_back(end_pos, color);
+  }
+
+  window.draw(ordered_vertices.data(), ordered_vertices.size(), sf::Lines);
+}
+
+std::pair<Eigen::Vector2d, Eigen::Vector2d>
+SfmlVisualizer::ComputeOffsetAndScaling() const {
+  Eigen::Vector2d offset = world_min_;
+  double scaling = std::min(kCanvasWidth / (world_max_ - world_min_).x(),
+                            kCanvasHeight / (world_max_ - world_min_).y());
+  return std::make_pair(offset, Eigen::Vector2d(scaling, scaling));
+}
+
+}  // namespace visualization
+}  // namespace cgzr

--- a/src/visualization/visualizer/sfml_visualizer.hpp
+++ b/src/visualization/visualizer/sfml_visualizer.hpp
@@ -1,0 +1,48 @@
+#ifndef SRC_VISUALIZATION_VISUALIZER_SFML_VISUALIZER_HPP_
+#define SRC_VISUALIZATION_VISUALIZER_SFML_VISUALIZER_HPP_
+
+#include <SFML/Graphics.hpp>
+
+#include "visualization/visualizer/visualizer_base.hpp"
+
+namespace cgzr {
+namespace visualization {
+
+class SfmlVisualizer : public VisualizerBase {
+ public:
+  SfmlVisualizer();
+
+  void Visualize() override;
+
+ private:
+  void DrawPointSet(sf::RenderWindow& window, const DrawableBase* drawable,
+                    const Eigen::Vector2d offset,
+                    const Eigen::Vector2d scaling) const;
+  void DrawLineString(sf::RenderWindow& window, const DrawableBase* drawable,
+                      const Eigen::Vector2d offset,
+                      const Eigen::Vector2d scaling) const;
+
+  /**
+   * @brief Calculates the offset and scaling (pixel-wise) that fits all the
+   * shapes into the fixed-sized canvas.
+   *
+   * pixel_coord = (original - offset) * scaling
+   *
+   * @return [offset, scaling]
+   */
+  std::pair<Eigen::Vector2d, Eigen::Vector2d> ComputeOffsetAndScaling() const;
+
+ private:
+  static constexpr unsigned int kCanvasWidth = 800;
+  static constexpr unsigned int kCanvasHeight = 600;
+  static constexpr unsigned int kCanvasWidthBuffer = 10;
+  static constexpr unsigned int kCanvasHeightBuffer = 10;
+
+ private:
+  sf::RenderWindow window_;
+};
+
+}  // namespace visualization
+}  // namespace cgzr
+
+#endif  // SRC_VISUALIZATION_VISUALIZER_SFML_VISUALIZER_HPP_

--- a/src/visualization/visualizer/visualizer_base.hpp
+++ b/src/visualization/visualizer/visualizer_base.hpp
@@ -25,7 +25,7 @@ class VisualizerBase {
         world_max_(std::numeric_limits<double>::infinity(),
                    std::numeric_limits<double>::infinity()) {}
   virtual ~VisualizerBase() {}
-  virtual void Visualize() const = 0;
+  virtual void Visualize() = 0;
 
   /**
    * @brief Adds the drawable into Visualizer and destroys it

--- a/test/test_sfml.cpp
+++ b/test/test_sfml.cpp
@@ -1,3 +1,10 @@
+/**
+ * @file test_sfml.cpp
+ *
+ * @brief Code copied and modified from
+ * https://www.sfml-dev.org/tutorials/2.6/graphics-draw.php
+ */
+
 #include <SFML/Graphics.hpp>
 
 int main() {


### PR DESCRIPTION
1. Fully incorporated SFML as a visualization backend into main code base;
2. Refactored const variable naming conventions to comply with Google standard;
3. Minor changes to `VisualizerBase` API.