### PR TITLE
feat(SFML): update SFML version

### DIFF
--- a/.github/workflows/vcpkg_build_debug.yml
+++ b/.github/workflows/vcpkg_build_debug.yml
@@ -41,7 +41,7 @@ jobs:
         id: run_vcpkg
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "fba81a6a545a66ef3de3a2d36c355f687f72a6b4"
+          vcpkgGitCommitId: "ce46ba8777d8f899d8dc11afefb8eca39293df39"
           vcpkgJsonGlob: "vcpkg.json"
           doNotCache: false
 

--- a/.github/workflows/vcpkg_build_release.yml
+++ b/.github/workflows/vcpkg_build_release.yml
@@ -42,7 +42,7 @@ jobs:
         id: run_vcpkg
         with:
           vcpkgDirectory: "${{ github.workspace }}/vcpkg"
-          vcpkgGitCommitId: "fba81a6a545a66ef3de3a2d36c355f687f72a6b4"
+          vcpkgGitCommitId: "ce46ba8777d8f899d8dc11afefb8eca39293df39"
           vcpkgJsonGlob: "vcpkg.json"
           doNotCache: false
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
     "eigen3",
     "spdlog",
     {"name": "sciplot", "version>=": "0.3.1"},
-    "sfml"
+    {"name": "sfml", "version>=": "2.6.1"}
   ],
-  "builtin-baseline": "fba81a6a545a66ef3de3a2d36c355f687f72a6b4"
+  "builtin-baseline": "ce46ba8777d8f899d8dc11afefb8eca39293df39"
 }


### PR DESCRIPTION
Bump vcpkg baseline to [ce46ba8](https://github.com/microsoft/vcpkg/commit/ce46ba8777d8f899d8dc11afefb8eca39293df39), require SFML >= 2.6.1 for macOS CMake issues